### PR TITLE
25-create-static-content-deployment-for-website

### DIFF
--- a/.github/workflows/deploy-dev-environment.yml
+++ b/.github/workflows/deploy-dev-environment.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -34,6 +35,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: projects/460847146789/locations/global/workloadIdentityPools/dev-pool/providers/dev-provider
+          service_account: terraform-cloud@cloud-resume-dev.iam.gserviceaccount.com
 
       # Runs a set of commands using the runners shell
       - name: Setup Terraform

--- a/.github/workflows/deploy-prod-environment.yml
+++ b/.github/workflows/deploy-prod-environment.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -31,6 +32,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: projects/357366557592/locations/global/workloadIdentityPools/prod-pool/providers/prod-provider
+          service_account: terraform-cloud@cloud-resume-prod.iam.gserviceaccount.com
 
       # Runs a set of commands using the runners shell
       - name: Setup Terraform

--- a/.github/workflows/deploy-uat-environment.yml
+++ b/.github/workflows/deploy-uat-environment.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 defaults:
   run:
@@ -26,6 +27,13 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: projects/358069862793/locations/global/workloadIdentityPools/uat-pool/providers/uat-provider
+          service_account: terraform-cloud@cloud-resume-uat.iam.gserviceaccount.com
 
       # Trigger CodeCov, to be expanded further in future commits
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/destroy-dev-environment.yml
+++ b/.github/workflows/destroy-dev-environment.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  id-token: write
 
 defaults:
   run:
@@ -19,6 +20,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: projects/460847146789/locations/global/workloadIdentityPools/dev-pool/providers/dev-provider
+          service_account: terraform-cloud@cloud-resume-dev.iam.gserviceaccount.com
 
       - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment

--- a/.github/workflows/destroy-uat-environment.yml
+++ b/.github/workflows/destroy-uat-environment.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: read
   deployments: write
+  id-token: write
 
 defaults:
   run:
@@ -21,6 +22,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: projects/358069862793/locations/global/workloadIdentityPools/uat-pool/providers/uat-provider
+          service_account: terraform-cloud@cloud-resume-uat.iam.gserviceaccount.com
 
       - uses: chrnorm/deployment-action@v2
         name: Create GitHub deployment

--- a/terraform/modules/frontend/main.tf
+++ b/terraform/modules/frontend/main.tf
@@ -25,3 +25,37 @@ resource "google_storage_bucket" "static_website" {
   }
 }
 
+resource "google_storage_bucket_object" "index_html" {
+  name         = "index.html"
+  bucket       = google_storage_bucket.static_website.name
+  source       = "../../frontend/index.html"
+  content_type = "text/html"
+}
+
+resource "google_storage_bucket_object" "error_html" {
+  name         = "error.html"
+  bucket       = google_storage_bucket.static_website.name
+  source       = "../../frontend/error.html"
+  content_type = "text/html"
+}
+
+resource "google_storage_bucket_object" "styles_css" {
+  name         = "styles.css"
+  bucket       = google_storage_bucket.static_website.name
+  source       = "../../frontend/styles.css"
+  content_type = "text/css"
+}
+
+resource "google_storage_bucket_object" "index_js" {
+  name         = "index.js"
+  bucket       = google_storage_bucket.static_website.name
+  source       = "../../frontend/index.js"
+  content_type = "text/javascript"
+}
+
+resource "google_storage_bucket_object" "nourez_jpg" {
+  name         = "nourez.jpg"
+  bucket       = google_storage_bucket.static_website.name
+  source       = "../../frontend/nourez.jpg"
+  content_type = "image/jpeg"
+}


### PR DESCRIPTION
Configured deployments for static content to buckets and also enabled OIDC on the pipelines as Terraform Cloud cannot access local files in the repo for deployment (thus requiring the use OIDC to connect to GCP and running Terraform "locallly" in the Github Action worker).